### PR TITLE
Update CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,7 +22,7 @@ endif(NOT CMAKE_BUILD_TYPE)
 
 
 # Macros and packages
-set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/cmake/Modules/")
+set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${PROJECT_SOURCE_DIR}/cmake/Modules/")
 
 # --- custom targets: ---
 if (NOT TARGET distclean)


### PR DESCRIPTION
When MATAR is built as a submodule of ELEMENTS or some other package, we need to make sure that MATAR is looking for its module files in its own `cmake/Modules/` directory and not the one belonging to the linking package. We should probably replace `CMAKE_SOURCE_DIR` with `PROJECT_SOURCE_DIR` not just here but wherever else it appears in MATAR.