### PR TITLE
Modified CMake version, C++ standard requirement

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,9 @@
-cmake_minimum_required(VERSION 3.1.3)
+# Usage of C++17 standard requires CMake version >= 3.8
+cmake_minimum_required(VERSION 3.8)
+
+# Current usage of shared_ptr in MATAR requires C++17 standard
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED TRUE)
 
 # set wrapper if compiling for CUDA and using gcc compiler
 if (KOKKOS)


### PR DESCRIPTION
Added this so that CMake requires the C++17, which is needed for the usage of `shared_ptr` in MATAR