### PR TITLE
Default String Array and Argument ordering

### DIFF
--- a/src/matar.h
+++ b/src/matar.h
@@ -12866,7 +12866,7 @@ class CSRArrayKokkos {
                CArrayKokkos<T, Layout, ExecSpace, MemoryTraits> &array,
                CArrayKokkos<size_t, Layout, ExecSpace, MemoryTraits> &start_index,
                CArrayKokkos<size_t, Layout, ExecSpace, MemoryTraits> &colum_index,
-               size_t dim1, size_t dim2, const std::string & tag_string);
+               size_t dim1, size_t dim2, const std::string & tag_string = DEFAULTSTRINGARRAY);
 
 
     /**
@@ -13343,7 +13343,7 @@ private: // What ought to be private ?
                CArrayKokkos<T, Layout, ExecSpace, MemoryTraits> &array,
                CArrayKokkos<size_t, Layout, ExecSpace, MemoryTraits> &start_index,
                CArrayKokkos<size_t, Layout, ExecSpace, MemoryTraits> &row_index,
-               size_t dim1, size_t dim2, const std::string & tag_string);
+               size_t dim1, size_t dim2, const std::string & tag_string = DEFAULTSTRINGARRAY);
 
 
       /**

--- a/src/matar.h
+++ b/src/matar.h
@@ -12863,8 +12863,8 @@ class CSRArrayKokkos {
     //CSRArray(CArray<T> data, CArray<T> col_ptrs, CArray<T> row_ptrs, size_t rows, size_t cols);
 
    CSRArrayKokkos(
-               CArrayKokkos<size_t, Layout, ExecSpace, MemoryTraits> &start_index,
                CArrayKokkos<T, Layout, ExecSpace, MemoryTraits> &array,
+               CArrayKokkos<size_t, Layout, ExecSpace, MemoryTraits> &start_index,
                CArrayKokkos<size_t, Layout, ExecSpace, MemoryTraits> &colum_index,
                size_t dim1, size_t dim2, const std::string & tag_string);
 
@@ -13027,8 +13027,8 @@ CSRArrayKokkos<T, Layout,ExecSpace, MemoryTraits>::CSRArrayKokkos() {}
 
 template<typename T, typename Layout, typename ExecSpace, typename MemoryTraits>
 CSRArrayKokkos<T,Layout,ExecSpace,MemoryTraits>::CSRArrayKokkos(
-               CArrayKokkos<size_t, Layout, ExecSpace, MemoryTraits> &start_index,
                CArrayKokkos<T, Layout, ExecSpace, MemoryTraits> &array,  
+               CArrayKokkos<size_t, Layout, ExecSpace, MemoryTraits> &start_index,
                CArrayKokkos<size_t, Layout, ExecSpace, MemoryTraits> &colum_index,
                size_t dim1, size_t dim2, const std::string & tag_string){
     dim1_ = dim1;
@@ -13340,8 +13340,8 @@ private: // What ought to be private ?
       * @param dim2: number of columns the matrix should have
       */
      CSCArrayKokkos(
-               CArrayKokkos<size_t, Layout, ExecSpace, MemoryTraits> &start_index,
                CArrayKokkos<T, Layout, ExecSpace, MemoryTraits> &array,
+               CArrayKokkos<size_t, Layout, ExecSpace, MemoryTraits> &start_index,
                CArrayKokkos<size_t, Layout, ExecSpace, MemoryTraits> &row_index,
                size_t dim1, size_t dim2, const std::string & tag_string);
 
@@ -13485,8 +13485,8 @@ CSCArrayKokkos<T, Layout, ExecSpace, MemoryTraits>::CSCArrayKokkos() {}
  
 template<typename T, typename Layout, typename ExecSpace, typename MemoryTraits>
 CSCArrayKokkos<T, Layout, ExecSpace, MemoryTraits>::CSCArrayKokkos(
-               CArrayKokkos<size_t, Layout, ExecSpace, MemoryTraits> &start_index,
                CArrayKokkos<T, Layout, ExecSpace, MemoryTraits> &array,
+               CArrayKokkos<size_t, Layout, ExecSpace, MemoryTraits> &start_index,
                CArrayKokkos<size_t, Layout, ExecSpace, MemoryTraits> &row_index,
                size_t dim1, size_t dim2, const std::string & tag_string){
 

--- a/test/CSCKokkos.cpp
+++ b/test/CSCKokkos.cpp
@@ -50,7 +50,7 @@ int main(int argc, char* argv[]){
     
     const std::string s = "hello";   
     // Testing = op 
-    auto pre_A = CSCArrayKokkos<int>(starts, array, rows, dim1, dim2, s);
+    auto pre_A = CSCArrayKokkos<int>(array, starts,rows, dim1, dim2, s);
     auto A = pre_A;
     int* values = A.pointer();
     auto a_start = A.get_starts();

--- a/test/CSRKokkos.cpp
+++ b/test/CSRKokkos.cpp
@@ -24,13 +24,32 @@ int main(int argc, char* argv[]){
          }
     });
 
+    int column_arr[] = {0, 2, 2, 0, 1, 2};
+    CArrayKokkos<double> data(6);
+    CArrayKokkos<size_t> row(4);
+    CArrayKokkos<size_t> column(6);
+    RUN ({
+        for(size_t i =0; i < 6; i++){
+            data(i) = i+1.5;
+            column(i) = column_arr[i];
+        }
+        row(0) = 0;
+        row(1) = 2;
+        row(2) = 3;
+        row(3) = 6; 
+    });
+
+    const std::string s = "Example";
+    CSRArrayKokkos<double> E( data, row, column, 3, 3, s);
+    
+
     /*
     |1 2 0 0 0 0 0 0 0 0|
     |0 0 3 4 0 0 0 0 0 0|
     |0 0 0 0 5 6 0 0 0 0|
     */
-    const std::string s = "hello";   
-    auto pre_A = CSRArrayKokkos<int>(starts, array, columns, dim1, dim2, s);
+    /*const std::string s = "hello";   
+    auto pre_A = CSRArrayKokkos<int>(array, starts, columns, dim1, dim2, s);
     auto A = pre_A;
   
     
@@ -64,7 +83,7 @@ int main(int argc, char* argv[]){
                     }, total);    
     printf("Sum of nnz in array notation %d\n", total);
     auto ss = A.begin(0);
-    
+    */
     } Kokkos::finalize();
     return 0; 
 


### PR DESCRIPTION
Switching ordering of arguments for CSR/CSC ArrayKokkos and changed both from required a string to it being optional in initialization. 