### PR TITLE
ENH: Add get_name functionality to kokkos types

### DIFF
--- a/examples/mtr-kokkos-simple.cpp
+++ b/examples/mtr-kokkos-simple.cpp
@@ -126,8 +126,12 @@ int main(int argc, char *argv[]) {
 
         // Matrix examples following the Fortran index convention,
         // indicies go from 1 to N, first index varies the fastest
-        FMatrixDevice <real_t> matrix1D(10);    // declare and allocate a 1D matrix of size 10
-        FMatrixDevice <real_t> matrix2D(10,10); // declare and allocate a 2D matrix with sizes of 10 x 10
+        FMatrixDevice <real_t> matrix1D(10, "1D_FMatrix");    // declare and allocate a 1D matrix of size 10
+        FMatrixDevice <real_t> matrix2D(10,10, "2D_FMatrix"); // declare and allocate a 2D matrix with sizes of 10 x 10
+
+        std::cout<< "Name of 1D Matrix = "<<matrix1D.get_name()<<std::endl;
+        std::cout<< "Name of 2D Matrix = "<<matrix2D.get_name()<<std::endl;
+
 
         FMatrixDevice <real_t> matrix3D;        // declare variable and allocate sizes and dimensions later
         matrix3D = FMatrixDevice <real_t> (10,10,10); // allocate dimensions and sizes 

--- a/src/include/kokkos_types.h
+++ b/src/include/kokkos_types.h
@@ -238,6 +238,10 @@ public:
     KOKKOS_INLINE_FUNCTION
     TArray1D get_kokkos_view() const;
 
+    // Get the name of the view
+    KOKKOS_INLINE_FUNCTION
+    const std::string get_name() const;
+
     // Destructor
     KOKKOS_INLINE_FUNCTION
     ~FArrayKokkos();
@@ -528,6 +532,14 @@ KOKKOS_INLINE_FUNCTION
 Kokkos::View<T*, Layout, ExecSpace, MemoryTraits> FArrayKokkos<T,Layout,ExecSpace,MemoryTraits>::get_kokkos_view() const {
     return this_array_;
 }
+
+// Get the name of the view
+template <typename T, typename Layout, typename ExecSpace, typename MemoryTraits>
+KOKKOS_INLINE_FUNCTION
+const std::string FArrayKokkos<T,Layout,ExecSpace,MemoryTraits>::get_name() const{
+    return this_array_.label();
+}
+
 
 // set values of array
 template <typename T, typename Layout, typename ExecSpace, typename MemoryTraits>
@@ -972,6 +984,10 @@ public:
     KOKKOS_INLINE_FUNCTION
     TArray1D get_kokkos_view() const;
 
+    // Get the name of the view
+    KOKKOS_INLINE_FUNCTION
+    const std::string get_name() const;
+
     KOKKOS_INLINE_FUNCTION
     ~FMatrixKokkos();
 
@@ -1245,6 +1261,14 @@ KOKKOS_INLINE_FUNCTION
 Kokkos::View<T*, Layout, ExecSpace, MemoryTraits> FMatrixKokkos<T,Layout,ExecSpace,MemoryTraits>::get_kokkos_view() const {
     return this_matrix_;
 }
+
+// Get the name of the view
+template <typename T, typename Layout, typename ExecSpace, typename MemoryTraits>
+KOKKOS_INLINE_FUNCTION
+const std::string FMatrixKokkos<T,Layout,ExecSpace,MemoryTraits>::get_name() const{
+    return this_matrix_.label();
+}
+
 
 // set values of array
 template <typename T, typename Layout, typename ExecSpace, typename MemoryTraits>
@@ -1704,6 +1728,10 @@ public:
     // Method that update device view
     void update_device();
 
+    // Get the name of the view
+    KOKKOS_INLINE_FUNCTION
+    const std::string get_name() const;
+
     // Deconstructor
     KOKKOS_INLINE_FUNCTION
     ~DFArrayKokkos ();
@@ -1995,6 +2023,13 @@ void DFArrayKokkos<T,Layout,ExecSpace,MemoryTraits>::update_device() {
     this_array_.template sync<typename TArray1D::execution_space>();
 }
 
+// Get the name of the view
+template <typename T, typename Layout, typename ExecSpace, typename MemoryTraits>
+KOKKOS_INLINE_FUNCTION
+const std::string DFArrayKokkos<T,Layout,ExecSpace,MemoryTraits>::get_name() const{
+    return this_array_.label();
+}
+
 template <typename T, typename Layout, typename ExecSpace, typename MemoryTraits>
 KOKKOS_INLINE_FUNCTION
 DFArrayKokkos<T,Layout,ExecSpace,MemoryTraits>::~DFArrayKokkos() {}
@@ -2106,6 +2141,10 @@ public:
 
     // Method that update device view
     void update_device();
+
+    // Get the name of the view
+    KOKKOS_INLINE_FUNCTION
+    const std::string get_name() const;
 
     // Deconstructor
     KOKKOS_INLINE_FUNCTION
@@ -2445,6 +2484,13 @@ void DViewFArrayKokkos<T,Layout,ExecSpace,MemoryTraits>::update_device() {
     deep_copy(this_array_, this_array_host_);
 }
 
+// Get the name of the view
+template <typename T, typename Layout, typename ExecSpace, typename MemoryTraits>
+KOKKOS_INLINE_FUNCTION
+const std::string DViewFArrayKokkos<T,Layout,ExecSpace,MemoryTraits>::get_name() const{
+    return this_array_.label();
+}
+
 template <typename T, typename Layout, typename ExecSpace, typename MemoryTraits>
 KOKKOS_INLINE_FUNCTION
 DViewFArrayKokkos<T,Layout,ExecSpace,MemoryTraits>::~DViewFArrayKokkos() {}
@@ -2546,6 +2592,10 @@ public:
 
     // Method that update device view
     void update_device();
+
+    // Get the name of the view
+    KOKKOS_INLINE_FUNCTION
+    const std::string get_name() const;
 
     // Deconstructor
     KOKKOS_INLINE_FUNCTION
@@ -2838,6 +2888,13 @@ void DFMatrixKokkos<T,Layout,ExecSpace,MemoryTraits>::update_device() {
     this_matrix_.template sync<typename TArray1D::execution_space>();
 }
 
+// Get the name of the view
+template <typename T, typename Layout, typename ExecSpace, typename MemoryTraits>
+KOKKOS_INLINE_FUNCTION
+const std::string DFMatrixKokkos<T,Layout,ExecSpace,MemoryTraits>::get_name() const{
+    return this_matrix_.label();
+}
+
 template <typename T, typename Layout, typename ExecSpace, typename MemoryTraits>
 KOKKOS_INLINE_FUNCTION
 DFMatrixKokkos<T,Layout,ExecSpace,MemoryTraits>::~DFMatrixKokkos() {}
@@ -2944,6 +3001,10 @@ public:
 
     // Method that update device view
     void update_device();
+
+    // Get the name of the view
+    KOKKOS_INLINE_FUNCTION
+    const std::string get_name() const;
 
     // Deconstructor
     KOKKOS_INLINE_FUNCTION
@@ -3273,6 +3334,14 @@ void DViewFMatrixKokkos<T,Layout,ExecSpace,MemoryTraits>::update_device() {
     deep_copy(this_matrix_, this_matrix_host_);
 }
 
+// Get the name of the view
+template <typename T, typename Layout, typename ExecSpace, typename MemoryTraits>
+KOKKOS_INLINE_FUNCTION
+const std::string DViewFMatrixKokkos<T,Layout,ExecSpace,MemoryTraits>::get_name() const{
+    return this_matrix_.label();
+}
+
+
 template <typename T, typename Layout, typename ExecSpace, typename MemoryTraits>
 KOKKOS_INLINE_FUNCTION
 DViewFMatrixKokkos<T,Layout,ExecSpace,MemoryTraits>::~DViewFMatrixKokkos() {}
@@ -3368,6 +3437,10 @@ public:
     //return the view
     KOKKOS_INLINE_FUNCTION
     TArray1D get_kokkos_view() const;
+
+    // Get the name of the view
+    KOKKOS_INLINE_FUNCTION
+    const std::string get_name() const;
 
     // Deconstructor
     KOKKOS_INLINE_FUNCTION
@@ -3638,6 +3711,13 @@ template <typename T, typename Layout, typename ExecSpace, typename MemoryTraits
 KOKKOS_INLINE_FUNCTION
 Kokkos::View<T*, Layout, ExecSpace, MemoryTraits> CArrayKokkos<T,Layout,ExecSpace,MemoryTraits>::get_kokkos_view() const {
     return this_array_;
+}
+
+// Get the name of the view
+template <typename T, typename Layout, typename ExecSpace, typename MemoryTraits>
+KOKKOS_INLINE_FUNCTION
+const std::string CArrayKokkos<T,Layout,ExecSpace,MemoryTraits>::get_name() const{
+    return this_array_.label();
 }
 
 // set values of array
@@ -4079,6 +4159,10 @@ public:
     KOKKOS_INLINE_FUNCTION
     TArray1D get_kokkos_view() const;
 
+    // Get the name of the view
+    KOKKOS_INLINE_FUNCTION
+    const std::string get_name() const;
+
     KOKKOS_INLINE_FUNCTION
     ~CMatrixKokkos();
 
@@ -4354,6 +4438,13 @@ template <typename T, typename Layout, typename ExecSpace, typename MemoryTraits
 KOKKOS_INLINE_FUNCTION
 Kokkos::View<T*, Layout, ExecSpace, MemoryTraits> CMatrixKokkos<T,Layout,ExecSpace,MemoryTraits>::get_kokkos_view() const {
     return this_matrix_;
+}
+
+// Get the name of the view
+template <typename T, typename Layout, typename ExecSpace, typename MemoryTraits>
+KOKKOS_INLINE_FUNCTION
+const std::string CMatrixKokkos<T,Layout,ExecSpace,MemoryTraits>::get_name() const{
+    return this_matrix_.label();
 }
 
 // set values of array
@@ -4797,6 +4888,10 @@ public:
     KOKKOS_INLINE_FUNCTION
     TArray1D get_kokkos_dual_view() const;
 
+    // Get the name of the view
+    KOKKOS_INLINE_FUNCTION
+    const std::string get_name() const;
+
     // Method that update host view
     void update_host();
 
@@ -5086,6 +5181,13 @@ Kokkos::DualView <T*, Layout, ExecSpace, MemoryTraits> DCArrayKokkos<T,Layout,Ex
   return this_array_;
 }
 
+// Get the name of the view
+template <typename T, typename Layout, typename ExecSpace, typename MemoryTraits>
+KOKKOS_INLINE_FUNCTION
+const std::string DCArrayKokkos<T,Layout,ExecSpace,MemoryTraits>::get_name() const{
+    return this_array_.label();
+}
+
 template <typename T, typename Layout, typename ExecSpace, typename MemoryTraits>
 void DCArrayKokkos<T,Layout,ExecSpace,MemoryTraits>::update_host() {
 
@@ -5207,6 +5309,10 @@ public:
 
     // Method that update device view
     void update_device();
+
+    // Get the name of the view
+    KOKKOS_INLINE_FUNCTION
+    const std::string get_name() const;
 
     // Deconstructor
     KOKKOS_INLINE_FUNCTION
@@ -5555,6 +5661,12 @@ void DViewCArrayKokkos<T,Layout,ExecSpace,MemoryTraits>::update_device() {
 
 template <typename T, typename Layout, typename ExecSpace, typename MemoryTraits>
 KOKKOS_INLINE_FUNCTION
+const std::string DViewCArrayKokkos<T,Layout,ExecSpace,MemoryTraits>::get_name() const{
+    return this_array_.label();
+}
+
+template <typename T, typename Layout, typename ExecSpace, typename MemoryTraits>
+KOKKOS_INLINE_FUNCTION
 DViewCArrayKokkos<T,Layout,ExecSpace,MemoryTraits>::~DViewCArrayKokkos() {}
 // End DViewCArrayKokkos
 
@@ -5654,6 +5766,10 @@ public:
 
     // Method that update device view
     void update_device();
+
+    // Get the name of the view
+    KOKKOS_INLINE_FUNCTION
+    const std::string get_name() const;
 
     // Deconstructor
     KOKKOS_INLINE_FUNCTION
@@ -5947,6 +6063,13 @@ void DCMatrixKokkos<T,Layout,ExecSpace,MemoryTraits>::update_device() {
     this_matrix_.template sync<typename TArray1D::execution_space>();
 }
 
+// Get the name of the view
+template <typename T, typename Layout, typename ExecSpace, typename MemoryTraits>
+KOKKOS_INLINE_FUNCTION
+const std::string DCMatrixKokkos<T,Layout,ExecSpace,MemoryTraits>::get_name() const{
+    return this_matrix_.label();
+}
+
 template <typename T, typename Layout, typename ExecSpace, typename MemoryTraits>
 KOKKOS_INLINE_FUNCTION
 DCMatrixKokkos<T,Layout,ExecSpace,MemoryTraits>::~DCMatrixKokkos() {}
@@ -6053,6 +6176,10 @@ public:
 
     // Method that update device view
     void update_device();
+
+    // Get the name of the view
+    KOKKOS_INLINE_FUNCTION
+    const std::string get_name() const;
 
     // Deconstructor
     KOKKOS_INLINE_FUNCTION
@@ -6382,6 +6509,13 @@ void DViewCMatrixKokkos<T,Layout,ExecSpace,MemoryTraits>::update_device() {
     deep_copy(this_matrix_, this_matrix_host_);
 }
 
+// Get the name of the view
+template <typename T, typename Layout, typename ExecSpace, typename MemoryTraits>
+KOKKOS_INLINE_FUNCTION
+const std::string DViewCMatrixKokkos<T,Layout,ExecSpace,MemoryTraits>::get_name() const{
+    return this_matrix_.label();
+}
+
 template <typename T, typename Layout, typename ExecSpace, typename MemoryTraits>
 KOKKOS_INLINE_FUNCTION
 DViewCMatrixKokkos<T,Layout,ExecSpace,MemoryTraits>::~DViewCMatrixKokkos() {}
@@ -6460,6 +6594,10 @@ public:
     //return the view
     KOKKOS_INLINE_FUNCTION
     TArray1D get_kokkos_view();
+
+    // Get the name of the view
+    KOKKOS_INLINE_FUNCTION
+    const std::string get_name() const;
 
     // Kokkos views of strides and start indices
     Strides1D mystrides_;
@@ -6780,6 +6918,14 @@ Kokkos::View<T*, Layout, ExecSpace, MemoryTraits> RaggedRightArrayKokkos<T,Layou
     return array_;
 }
 
+// Get the name of the view
+template <typename T, typename Layout, typename ExecSpace, typename MemoryTraits, typename ILayout>
+KOKKOS_INLINE_FUNCTION
+const std::string RaggedRightArrayKokkos<T,Layout,ExecSpace,MemoryTraits,ILayout>::get_name() const{
+    return array_.label();
+}
+
+
 // Destructor
 template <typename T, typename Layout, typename ExecSpace, typename MemoryTraits, typename ILayout>
 KOKKOS_INLINE_FUNCTION
@@ -6855,6 +7001,10 @@ public:
     //return the view
     KOKKOS_INLINE_FUNCTION
     TArray1D get_kokkos_view();
+
+    // Get the name of the view
+    KOKKOS_INLINE_FUNCTION
+    const std::string get_name() const;
 
     // Kokkos views of strides and start indices
     Strides1D mystrides_;
@@ -7126,6 +7276,13 @@ Kokkos::View<T*, Layout, ExecSpace, MemoryTraits> RaggedRightArrayofVectorsKokko
     return array_;
 }
 
+// Get the name of the view
+template <typename T, typename Layout, typename ExecSpace, typename MemoryTraits, typename ILayout>
+KOKKOS_INLINE_FUNCTION
+const std::string RaggedRightArrayofVectorsKokkos<T,Layout,ExecSpace,MemoryTraits,ILayout>::get_name() const{
+    return array_.label();
+}
+
 // Destructor
 template <typename T, typename Layout, typename ExecSpace, typename MemoryTraits, typename ILayout>
 KOKKOS_INLINE_FUNCTION
@@ -7185,6 +7342,10 @@ public:
     //return the view
     KOKKOS_INLINE_FUNCTION
     TArray1D get_kokkos_view();
+
+    // Get the name of the view
+    KOKKOS_INLINE_FUNCTION
+    const std::string get_name() const;
     
     KOKKOS_INLINE_FUNCTION
     RaggedDownArrayKokkos& operator= (const RaggedDownArrayKokkos &temp);
@@ -7473,6 +7634,13 @@ Kokkos::View<T*, Layout, ExecSpace, MemoryTraits> RaggedDownArrayKokkos<T,Layout
     return array_;
 }
 
+// Get the name of the view
+template <typename T, typename Layout, typename ExecSpace, typename MemoryTraits, typename ILayout>
+KOKKOS_INLINE_FUNCTION
+const std::string RaggedDownArrayKokkos<T,Layout,ExecSpace,MemoryTraits,ILayout>::get_name() const{
+    return array_.label();
+}
+
 // Destructor
 template <typename T, typename Layout, typename ExecSpace, typename MemoryTraits, typename ILayout>
 KOKKOS_INLINE_FUNCTION
@@ -7518,6 +7686,10 @@ public:
     //return the view
     KOKKOS_INLINE_FUNCTION
     TArray1D get_kokkos_view();
+
+    // Get the name of the view
+    KOKKOS_INLINE_FUNCTION
+    const std::string get_name() const;
     
     // Overload operator() to access data as array(i,j),
     // where i=[0:N-1], j=[stride(i)]
@@ -7648,6 +7820,13 @@ Kokkos::View<T*, Layout, ExecSpace, MemoryTraits> DynamicRaggedRightArrayKokkos<
     return array_;
 }
 
+// Get the name of the view
+template <typename T, typename Layout, typename ExecSpace, typename MemoryTraits>
+KOKKOS_INLINE_FUNCTION
+const std::string DynamicRaggedRightArrayKokkos<T,Layout,ExecSpace,MemoryTraits>::get_name() const{
+    return array_.label();
+}
+
 // Destructor
 template <typename T, typename Layout, typename ExecSpace, typename MemoryTraits>
 KOKKOS_INLINE_FUNCTION
@@ -7696,6 +7875,10 @@ public:
     //return the view
     KOKKOS_INLINE_FUNCTION
     TArray1D get_kokkos_view();
+
+    // Get the name of the view
+    KOKKOS_INLINE_FUNCTION
+    const std::string get_name() const;
     
     // Overload operator() to access data as array(i,j),
     // where i=[stride(j)], j=[0:N-1]
@@ -7826,6 +8009,13 @@ Kokkos::View<T*, Layout, ExecSpace, MemoryTraits> DynamicRaggedDownArrayKokkos<T
     return array_;
 }
 
+// Get the name of the view
+template <typename T, typename Layout, typename ExecSpace, typename MemoryTraits>
+KOKKOS_INLINE_FUNCTION
+const std::string DynamicRaggedDownArrayKokkos<T,Layout,ExecSpace,MemoryTraits>::get_name() const{
+    return array_.label();
+}
+
 // Destructor
 template <typename T, typename Layout, typename ExecSpace, typename MemoryTraits>
 KOKKOS_INLINE_FUNCTION
@@ -7857,7 +8047,7 @@ class CSRArrayKokkos {
     CSRArrayKokkos();
     //CSRArray(CArray<T> data, CArray<T> col_ptrs, CArray<T> row_ptrs, size_t rows, size_t cols);
 
-   CSRArrayKokkos(
+    CSRArrayKokkos(
                CArrayKokkos<T, Layout, ExecSpace, MemoryTraits> &array,
                CArrayKokkos<size_t, Layout, ExecSpace, MemoryTraits> &start_index,
                CArrayKokkos<size_t, Layout, ExecSpace, MemoryTraits> &colum_index,
@@ -8001,6 +8191,10 @@ class CSRArrayKokkos {
     // int toCSC(CArray<T> &data, CArray<size_t> &col_ptrs, CArray<size_t> &row_ptrs);
 
     void to_dense(CArrayKokkos<T,Layout, ExecSpace, MemoryTraits>& A);
+
+    // Get the name of the view
+    KOKKOS_INLINE_FUNCTION
+    const std::string get_name() const;
     
     class init_start_indices_functor{
        public:
@@ -8240,6 +8434,13 @@ T& CSRArrayKokkos<T,Layout,ExecSpace, MemoryTraits>::get_val_flat(size_t k) cons
    return array_.data()[k];
 }
 
+// Get the name of the view
+template<typename T, typename Layout, typename ExecSpace, typename MemoryTraits>
+KOKKOS_INLINE_FUNCTION
+const std::string CSRArrayKokkos<T,Layout,ExecSpace, MemoryTraits>::get_name() const{
+    return array_.label();
+}
+
 template<typename T, typename Layout, typename ExecSpace, typename MemoryTraits>
 KOKKOS_INLINE_FUNCTION
 size_t CSRArrayKokkos<T,Layout,ExecSpace,MemoryTraits>::get_col_flat(size_t k) const{
@@ -8260,6 +8461,8 @@ int CSRArrayKokkos<T,Layout, ExecSpace, MemoryTraits>::flat_index(size_t i, size
     }
     return  -1;
 }
+
+
 
 //template<typename T, typename Layout, typename ExecSpace, typename MemoryTraits>
 //void CSRArrrayKokkos<T,Layout,ExecSpace, MemoryTraits>::from_dense(CArrayKokkos<T, Layout, ExecSpace, MemoryTraits> &starts,
@@ -8475,6 +8678,10 @@ private: // What ought to be private ?
       // reverse map function from A(i,j) to what element of data/col_pt_ it corersponds to
       KOKKOS_INLINE_FUNCTION
       int flat_index(size_t i, size_t j);
+
+      // Get the name of the view
+    KOKKOS_INLINE_FUNCTION
+    const std::string get_name() const;
       
       // Convertor
       //int toCSR(CArray<T> &data, CArray<size_t> &row_ptrs, CArray<size_t> &col_ptrs);
@@ -8633,6 +8840,13 @@ KOKKOS_INLINE_FUNCTION
 T& CSCArrayKokkos<T,Layout, ExecSpace, MemoryTraits>::get_val_flat(size_t k){
     return array_.data()[k];
 }
+
+template<typename T, typename Layout, typename ExecSpace, typename MemoryTraits>
+KOKKOS_INLINE_FUNCTION
+const std::string CSCArrayKokkos<T,Layout, ExecSpace, MemoryTraits>::get_name() const{
+    return array_.label();
+}
+
 
 template<typename T, typename Layout, typename ExecSpace, typename MemoryTraits>
 KOKKOS_INLINE_FUNCTION

--- a/test/test_cases/test_CArrayKokkos.cpp
+++ b/test/test_cases/test_CArrayKokkos.cpp
@@ -25,7 +25,7 @@ CArrayKokkos<double> return_CArrayKokkos(int dims, std::vector<int> sizes)
         A = CArrayKokkos<double>(sizes[0], sizes[1], sizes[2], sizes[3], sizes[4], "A_5D_CArrayKokkos");
     }
     else if(dims == 6){
-        A = CArrayKokkos<double>(sizes[0], sizes[1], sizes[2], sizes[3], sizes[4], sizes[5], "A_7D_CArrayKokkos");
+        A = CArrayKokkos<double>(sizes[0], sizes[1], sizes[2], sizes[3], sizes[4], sizes[5], "A_6D_CArrayKokkos");
     }
     else if(dims == 7){
         A = CArrayKokkos<double>(sizes[0], sizes[1], sizes[2], sizes[3], sizes[4], sizes[5], sizes[6], "A_7D_CArrayKokkos");
@@ -108,7 +108,7 @@ TEST(Test_CArrayKokkos, order)
 }
 
 
-// Test order function
+// Test pointer function
 TEST(Test_CArrayKokkos, pointer)
 {
     std::vector<int> sizes;
@@ -120,6 +120,29 @@ TEST(Test_CArrayKokkos, pointer)
         auto a = A.get_kokkos_view();
 
         EXPECT_EQ(&a[0], A.pointer());
+    }
+}
+
+// Test get name function
+TEST(Test_CArrayKokkos, names)
+{
+    std::vector<int> sizes;
+    std::vector <std::string> names = {
+        "A_1D_CArrayKokkos",
+        "A_2D_CArrayKokkos",
+        "A_3D_CArrayKokkos",
+        "A_4D_CArrayKokkos",
+        "A_5D_CArrayKokkos",
+        "A_6D_CArrayKokkos",
+        "A_7D_CArrayKokkos"
+    };
+
+    for(int i = 0; i < 7; i++){
+
+        int dims = i+1;
+        sizes.push_back(dims*2);
+        CArrayKokkos<double> A = return_CArrayKokkos(dims, sizes);
+        EXPECT_EQ(names[i], A.get_name());
     }
 }
 


### PR DESCRIPTION
Adds the ability to get the string label for kokkos views.  Handy for outputs. 

I added a few test, both in the simple matar example and the google tests for the CArrayKokkos. At some point, we need to improve unit test coverage. 

All test pass.  Builds with CUDA. 