### PR TITLE
BUG: Remove extra set_values() function declarations

### DIFF
--- a/src/include/kokkos_types.h
+++ b/src/include/kokkos_types.h
@@ -7536,10 +7536,6 @@ public:
     
     //print values
     void print() const;
-    
-    //set values to input
-    KOKKOS_INLINE_FUNCTION
-    void set_values(T val);
 
     // Kokkos views of strides and start indices
     Strides1D mystrides_;
@@ -7895,10 +7891,6 @@ public:
     KOKKOS_INLINE_FUNCTION
     const std::string get_name() const;
     
-    // set values to input
-    KOKKOS_INLINE_FUNCTION
-    void set_values(T val);
-    
     // Overload operator() to access data as array(i,j),
     // where i=[0:N-1], j=[stride(i)]
     KOKKOS_INLINE_FUNCTION
@@ -8114,10 +8106,6 @@ public:
     // Get the name of the view
     KOKKOS_INLINE_FUNCTION
     const std::string get_name() const;
-    
-    //set values to input
-    KOKKOS_INLINE_FUNCTION
-    void set_values(T val);
     
     // Overload operator() to access data as array(i,j),
     // where i=[stride(j)], j=[0:N-1]


### PR DESCRIPTION
There were duplicate declarations in the ragged data types for set_values().  Probably a merge issue. This PR removes the extra one. 