### PR TITLE
updated CMakeLists.txt to work with anaconda cuda

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -49,6 +49,9 @@ target_include_directories(matar INTERFACE
 )
 
 if(Matar_ENABLE_KOKKOS)
+    if(Matar_CUDA_BUILD)
+        find_package(CUDAToolkit REQUIRED)
+    endif()
     if("${Matar_KOKKOS_PACKAGE}" STREQUAL "Trilinos")
         find_package(Trilinos REQUIRED)
         add_definitions(-DTRILINOS_INTERFACE=1)

--- a/scripts/matar-install.sh
+++ b/scripts/matar-install.sh
@@ -19,6 +19,11 @@ else
     cmake_options+=(
         -D Matar_ENABLE_KOKKOS=ON
     )
+    if [ "$kokkos_build_type" = "cuda" ]; then
+        cmake_options+=(
+            -D Matar_CUDA_BUILD=ON
+        )
+    fi
 fi
 
 if [[ "$kokkos_build_type" = *"mpi"* ]]; then


### PR DESCRIPTION
Added a couple lines if we're building with Cuda and Anaconda. Does not affect the build for non-anaconda Cuda builds.

If we are building with Anaconda, it was not sufficient to rely on Kokkos's finding CUDAToolkit package, we needed that line as well.