### PR TITLE
BUG: Fix accessor in ViewFArrayKokkos type.

### DIFF
--- a/src/include/kokkos_types.h
+++ b/src/include/kokkos_types.h
@@ -893,7 +893,7 @@ T* ViewFArrayKokkos<T>::pointer() const {
 template <typename T>
 void ViewFArrayKokkos<T>::set_values(T val) {
     Kokkos::parallel_for( Kokkos::RangePolicy<> ( 0, length_), KOKKOS_CLASS_LAMBDA(const int i){
-        this_array_(i) = val;
+        this_array_[i] = val;
     });
 }
 


### PR DESCRIPTION
Accessor for set_values used () instead of [] for this_array_.