### PR TITLE
BUG: Fixing compiler warning with MPI types

### DIFF
--- a/src/include/macros.h
+++ b/src/include/macros.h
@@ -202,8 +202,6 @@
 
 
 // the REDUCE Product loop
-
-
 #define \
     RPROD1D(i, x0, x1, var, fcn, result) \
     Kokkos::parallel_reduce( \
@@ -230,6 +228,41 @@
     EXPAND(GET_MACRO(__VA_ARGS__, _13, RPROD3D, _11, _10, RPROD2D, _8, _7, RPROD1D)(__VA_ARGS__))
 
 
+
+
+// the REDUCE Product loop for a class
+#define \
+    RPRODCLASS1D(i, x0, x1, var, fcn, result) \
+    Kokkos::parallel_reduce( \
+                        Kokkos::RangePolicy<> ( (x0), (x1) ),  \
+                        KOKKOS_CLASS_LAMBDA(const int (i), decltype(var) &(var)){fcn}, \
+                        Kokkos::Prod< decltype(result) > ( (result) ) )
+
+#define \
+    RPRODCLASS2D(i, x0, x1, j, y0, y1, var, fcn, result) \
+    Kokkos::parallel_reduce( \
+        Kokkos::MDRangePolicy< Kokkos::Rank<2,LOOP_ORDER,LOOP_ORDER> > ( {(x0), (y0)}, {(x1), (y1)} ), \
+        KOKKOS_CLASS_LAMBDA( const int (i),const int (j), decltype(var) &(var) ){fcn}, \
+        Kokkos::Prod< decltype(result) > ( (result) ) )
+
+#define \
+    RPRODCLASS3D(i, x0, x1, j, y0, y1, k, z0, z1, var, fcn, result) \
+    Kokkos::parallel_reduce( \
+        Kokkos::MDRangePolicy< Kokkos::Rank<3,LOOP_ORDER,LOOP_ORDER> > ( {(x0), (y0), (z0)}, {(x1), (y1), (z1)} ), \
+        KOKKOS_CLASS_LAMBDA( const int (i), const int (j), const int (k), decltype(var) &(var) ){fcn}, \
+        Kokkos::Prod< decltype(result) > ( (result) ) )
+
+#define \
+    FOR_REDUCE_PRODUCT_CLASS(...) \
+    EXPAND(GET_MACRO(__VA_ARGS__, _13, RPRODCLASS3D, _11, _10, RPRODCLASS2D, _8, _7, RPRODCLASS1D)(__VA_ARGS__))
+
+
+
+
+
+
+
+
 // the DO_REDUCE_SUM loop
 #define \
     DO_RSUM1D(i, x0, x1, var, fcn, result) \
@@ -253,6 +286,8 @@
 #define \
     DO_REDUCE_SUM(...) \
     EXPAND(GET_MACRO(__VA_ARGS__, _13, DO_RSUM3D, _11, _10, DO_RSUM2D, _8, _7, DO_RSUM1D)(__VA_ARGS__))
+
+
 
 
 // the REDUCE MAX loop

--- a/src/include/mpi_types.h
+++ b/src/include/mpi_types.h
@@ -672,7 +672,7 @@ T MPICArrayKokkos<T, Layout, ExecSpace, MemoryTraits>::all_reduce(operation op) 
         case operation::sum: {
             local = 0;
             T loc_sum = 0;
-            FOR_REDUCE_SUM(i, 0, owned_len,
+            FOR_REDUCE_SUM_CLASS(i, 0, owned_len,
                         loc_sum, {
                 loc_sum += this_array_(i);
             }, local);
@@ -681,7 +681,7 @@ T MPICArrayKokkos<T, Layout, ExecSpace, MemoryTraits>::all_reduce(operation op) 
         case operation::product: {
             local = T(1);
             T loc_prod = 1;
-            FOR_REDUCE_PRODUCT(i, 0, owned_len,
+            FOR_REDUCE_PRODUCT_CLASS(i, 0, owned_len,
                         loc_prod, {
                 loc_prod *= this_array_(i);
             }, local);
@@ -690,7 +690,7 @@ T MPICArrayKokkos<T, Layout, ExecSpace, MemoryTraits>::all_reduce(operation op) 
         case operation::max: {
             local = this_array_(0);
             T loc_max = this_array_(0);
-            FOR_REDUCE_MAX(i, 0, owned_len,
+            FOR_REDUCE_MAX_CLASS(i, 0, owned_len,
                         loc_max, {
                 loc_max = (this_array_(i) > loc_max) ? this_array_(i) : loc_max;
             }, local);
@@ -699,7 +699,7 @@ T MPICArrayKokkos<T, Layout, ExecSpace, MemoryTraits>::all_reduce(operation op) 
         case operation::min: {
             local = this_array_(0);
             T loc_min = this_array_(0);
-            FOR_REDUCE_MIN(i, 0, owned_len,
+            FOR_REDUCE_MIN_CLASS(i, 0, owned_len,
                         loc_min, {
                 loc_min = (this_array_(i) < loc_min) ? this_array_(i) : loc_min;
             }, local);
@@ -740,7 +740,7 @@ T MPICArrayKokkos<T, Layout, ExecSpace, MemoryTraits>::all_reduce(operation op, 
         case operation::sum: {
             local = 0;
             T loc_sum = 0;
-            FOR_REDUCE_SUM(e, 0, owned_len, loc_sum, {
+            FOR_REDUCE_SUM_CLASS(e, 0, owned_len, loc_sum, {
                 loc_sum += this_array_(e, j);
             }, local);
             break;
@@ -748,7 +748,7 @@ T MPICArrayKokkos<T, Layout, ExecSpace, MemoryTraits>::all_reduce(operation op, 
         case operation::product: {
             local = T(1);
             T loc_prod = 1;
-            FOR_REDUCE_PRODUCT(e, 0, owned_len, loc_prod, {
+            FOR_REDUCE_PRODUCT_CLASS(e, 0, owned_len, loc_prod, {
                 loc_prod *= this_array_(e, j);
             }, local);
             break;
@@ -756,7 +756,7 @@ T MPICArrayKokkos<T, Layout, ExecSpace, MemoryTraits>::all_reduce(operation op, 
         case operation::max: {
             local = this_array_(0, j);
             T loc_max = local;
-            FOR_REDUCE_MAX(e, 0, owned_len, loc_max, {
+            FOR_REDUCE_MAX_CLASS(e, 0, owned_len, loc_max, {
                 const T v = this_array_(e, j);
                 loc_max = (v > loc_max) ? v : loc_max;
             }, local);
@@ -765,7 +765,7 @@ T MPICArrayKokkos<T, Layout, ExecSpace, MemoryTraits>::all_reduce(operation op, 
         case operation::min: {
             local = this_array_(0, j);
             T loc_min = local;
-            FOR_REDUCE_MIN(e, 0, owned_len, loc_min, {
+            FOR_REDUCE_MIN_CLASS(e, 0, owned_len, loc_min, {
                 const T v = this_array_(e, j);
                 loc_min = (v < loc_min) ? v : loc_min;
             }, local);
@@ -806,7 +806,7 @@ T MPICArrayKokkos<T, Layout, ExecSpace, MemoryTraits>::all_reduce(operation op, 
         case operation::sum: {
             local = 0;
             T loc_sum = 0;
-            FOR_REDUCE_SUM(e, 0, owned_len, loc_sum, {
+            FOR_REDUCE_SUM_CLASS(e, 0, owned_len, loc_sum, {
                 loc_sum += this_array_(e, j, k);
             }, local);
             break;
@@ -814,7 +814,7 @@ T MPICArrayKokkos<T, Layout, ExecSpace, MemoryTraits>::all_reduce(operation op, 
         case operation::product: {
             local = T(1);
             T loc_prod = 1;
-            FOR_REDUCE_PRODUCT(e, 0, owned_len, loc_prod, {
+            FOR_REDUCE_PRODUCT_CLASS(e, 0, owned_len, loc_prod, {
                 loc_prod *= this_array_(e, j, k);
             }, local);
             break;
@@ -822,7 +822,7 @@ T MPICArrayKokkos<T, Layout, ExecSpace, MemoryTraits>::all_reduce(operation op, 
         case operation::max: {
             local = this_array_(0, j, k);
             T loc_max = local;
-            FOR_REDUCE_MAX(e, 0, owned_len, loc_max, {
+            FOR_REDUCE_MAX_CLASS(e, 0, owned_len, loc_max, {
                 const T v = this_array_(e, j, k);
                 loc_max = (v > loc_max) ? v : loc_max;
             }, local);
@@ -831,7 +831,7 @@ T MPICArrayKokkos<T, Layout, ExecSpace, MemoryTraits>::all_reduce(operation op, 
         case operation::min: {
             local = this_array_(0, j, k);
             T loc_min = local;
-            FOR_REDUCE_MIN(e, 0, owned_len, loc_min, {
+            FOR_REDUCE_MIN_CLASS(e, 0, owned_len, loc_min, {
                 const T v = this_array_(e, j, k);
                 loc_min = (v < loc_min) ? v : loc_min;
             }, local);
@@ -874,7 +874,7 @@ T MPICArrayKokkos<T, Layout, ExecSpace, MemoryTraits>::all_reduce(operation op, 
         case operation::sum: {
             local = 0;
             T loc_sum = 0;
-            FOR_REDUCE_SUM(e, 0, owned_len, loc_sum, {
+            FOR_REDUCE_SUM_CLASS(e, 0, owned_len, loc_sum, {
                 loc_sum += this_array_(e, g, ti, tj);
             }, local);
             break;
@@ -882,7 +882,7 @@ T MPICArrayKokkos<T, Layout, ExecSpace, MemoryTraits>::all_reduce(operation op, 
         case operation::product: {
             local = T(1);
             T loc_prod = 1;
-            FOR_REDUCE_PRODUCT(e, 0, owned_len, loc_prod, {
+            FOR_REDUCE_PRODUCT_CLASS(e, 0, owned_len, loc_prod, {
                 loc_prod *= this_array_(e, g, ti, tj);
             }, local);
             break;
@@ -890,7 +890,7 @@ T MPICArrayKokkos<T, Layout, ExecSpace, MemoryTraits>::all_reduce(operation op, 
         case operation::max: {
             local = this_array_(0, g, ti, tj);
             T loc_max = local;
-            FOR_REDUCE_MAX(e, 0, owned_len, loc_max, {
+            FOR_REDUCE_MAX_CLASS(e, 0, owned_len, loc_max, {
                 const T v = this_array_(e, g, ti, tj);
                 loc_max = (v > loc_max) ? v : loc_max;
             }, local);
@@ -899,7 +899,7 @@ T MPICArrayKokkos<T, Layout, ExecSpace, MemoryTraits>::all_reduce(operation op, 
         case operation::min: {
             local = this_array_(0, g, ti, tj);
             T loc_min = local;
-            FOR_REDUCE_MIN(e, 0, owned_len, loc_min, {
+            FOR_REDUCE_MIN_CLASS(e, 0, owned_len, loc_min, {
                 const T v = this_array_(e, g, ti, tj);
                 loc_min = (v < loc_min) ? v : loc_min;
             }, local);


### PR DESCRIPTION
Adds a macro for FOR_REDUCE_PRODUCT_CLASS, and silences compiler warnings with CUDA builds. 