### PR TITLE
Cramers rule

### DIFF
--- a/solvers/lu_solver.hpp
+++ b/solvers/lu_solver.hpp
@@ -457,8 +457,8 @@ int LU_decompose_host(
 // inside this function are run on the GPU
 template <typename T1, typename T2, typename T3>
 void LU_backsub_host(
-    T1 &A,     // input matrix A in LU decomp format
-    T2 &perm,  // permutations (array <size_t>)
+    const T1 &A,     // input matrix A in LU decomp format
+    const T2 &perm,  // permutations (array <size_t>)
     T3 &b){          // RHS and is answer x to Ax=B
 
     const int n = A.dims(0);    // size of matrix

--- a/solvers/lu_solver.hpp
+++ b/solvers/lu_solver.hpp
@@ -165,8 +165,8 @@ int LU_decompose(
 // -------------------------------
 
 // this function is run on the GPU
-KOKKOS_FUNCTION
 template <typename T1, typename T2, typename T3>
+KOKKOS_FUNCTION
 void LU_backsub(
     const T1 &A,     // input matrix A in LU decomp format
     const T2 &perm,  // permutations (array <size_t>)

--- a/solvers/lu_solver.hpp
+++ b/solvers/lu_solver.hpp
@@ -56,12 +56,12 @@ const double TINY = 1e-15;
 template <typename T1, typename T2, typename T3>
 KOKKOS_FUNCTION
 int LU_decompose(
-    const T1 &A,     // matrix A passed in and is sent out in LU decomp format
-    const T2 &perm,  // permutations (array <size_t>)
-    const T3 &vv,
-    int &parity) {                 // parity (+1 or -1)
+    const T1 &A,     // device array A (e.g., DCArrayKokkos <double>) passed in and is sent out in LU decomp format
+    const T2 &perm,  // permutations (e.g., DCArrayKokkos <size_t>)
+    const T3 &vv,    // helper array (e.g., CArrayKokkos <double>) 
+    int &parity) {   // parity (+1 or -1)
                           
-    const int n = A.dims(0);  // size of matrix 
+    const int n = A.dims(0);  // size of array 
 
     parity = 1;
 
@@ -69,7 +69,7 @@ int LU_decompose(
     double temp;
     
     // search for the largest element in each row; save the scaling in the 
-    // temporary array vv and return zero if the matrix is singular 
+    // temporary array vv and return zero if the array is singular 
     for(size_t i = 0; i < n; i++) {
         
         double big = 0.;
@@ -137,7 +137,7 @@ int LU_decompose(
         
         // store the index
         perm(j) = imax;
-        // if the pivot element is zero, the matrix is singular but for some 
+        // if the pivot element is zero, the array is singular but for some 
         // applications a tiny number is desirable instead 
         
         if(A(j,j) == 0.0){
@@ -168,11 +168,11 @@ int LU_decompose(
 template <typename T1, typename T2, typename T3>
 KOKKOS_FUNCTION
 void LU_backsub(
-    const T1 &A,     // input matrix A in LU decomp format
-    const T2 &perm,  // permutations (array <size_t>)
-    const T3 &b){    // RHS and is answer x to Ax=B
+    const T1 &A,     // input array A (e.g., DCArrayKokkos <double>) in LU decomp format
+    const T2 &perm,  // permutations (e.g., DCArrayKokkos <size_t>)
+    const T3 &b){    // RHS and is answer x to Ax=B (e.g., DCArrayKokkos <double>)
 
-        const int n = A.dims(0);    // size of matrix
+        const int n = A.dims(0);    // size of array
 
         int ii = -1;
 
@@ -220,12 +220,12 @@ void LU_backsub(
 template <typename T1, typename T2, typename T3, typename T4>
 KOKKOS_INLINE_FUNCTION
 void LU_invert(
-    T1 &A,       // input matrix
-    T2 &perm,    // permutations
-    T3 &inv_mat, // inverse matrix
-    T4 &col) {   // tmp array
+    T1 &A,       // input array, e.g., DCArrayKokkos <double>
+    T2 &perm,    // permutations, e.g., DCArrayKokkos <size_t>
+    T3 &inv_mat, // inverse array, e.g., DCArrayKokkos <double>
+    T4 &col) {   // tmp array, e.g., DCArrayKokkos <double>
 
-    const size_t n = A.dims(0);    // size of matrix
+    const size_t n = A.dims(0);    // size of array
 
 
     for(size_t j = 0; j < n; j++){
@@ -250,15 +250,15 @@ void LU_invert(
 // -----------------------
 // LU determinant function 
 //  Input:  A filled in LUPDecompose; N - dimension.
-//  Output: determinate of original A matrix
+//  Output: determinate of original A array
 // ----------------------- 
 template <typename T>
 KOKKOS_INLINE_FUNCTION
 double LU_determinant(
-    T &A,               // input matrix
+    T &A,               // input array, e.g., DCArrayKokkos <double>
     const int parity){  // parity (+1 0r -1)
 
-    const int n = A.dims(0);    // size of matrix
+    const int n = A.dims(0);    // size of array
 
     double res = (double)(parity);
     
@@ -283,12 +283,12 @@ double LU_determinant(
 // inside this function are run on the GPU
 template <typename T1, typename T2, typename T3>
 int LU_decompose_host(
-    T1 &A,     // matrix A passed in and is sent out in LU decomp format
-    T2 &perm,  // permutations (array <size_t>)
-    T3 &vv,    // helper array 
+    T1 &A,     // device array A (e.g., DCArrayKokkos <double>) passed in and is sent out in LU decomp format
+    T2 &perm,  // permutations (e.g., DCArrayKokkos <size_t>)
+    T3 &vv,    // helper array (e.g., CArrayKokkos <double>) 
     int &parity) {                 // parity (+1 or -1)
                           
-    const int n = A.dims(0);  // size of matrix 
+    const int n = A.dims(0);  // size of array 
 
     CArrayKokkos <double> temp_scalar(1); // persistant scalar on device
 
@@ -296,7 +296,7 @@ int LU_decompose_host(
     
     // STEP 1:
     // search for the largest element in each row; save the scaling in the 
-    // temporary array vv and return zero if the matrix is singular
+    // temporary array vv and return zero if the array is singular
     FOR_FIRST(i, 0, n, {
         
         double max_val = 0.0;
@@ -322,7 +322,7 @@ int LU_decompose_host(
         min_val_lcl = fmin(vv(i), min_val_lcl);
 
     }, min_val);
-    if(min_val < TINY) return(0); // singular matrix as all row values are 0
+    if(min_val < TINY) return(0); // singular array as all row values are 0
 
 
     // STEP 2:
@@ -422,7 +422,7 @@ int LU_decompose_host(
         });
 
 
-        // if the pivot element is zero, the matrix is singular but for some 
+        // if the pivot element is zero, the array is singular but for some 
         // applications a tiny number is desirable instead 
         RUN({
             if(A(j,j) == 0.0){
@@ -457,11 +457,11 @@ int LU_decompose_host(
 // inside this function are run on the GPU
 template <typename T1, typename T2, typename T3>
 void LU_backsub_host(
-    const T1 &A,     // input matrix A in LU decomp format
-    const T2 &perm,  // permutations (array <size_t>)
-    T3 &b){          // RHS and is answer x to Ax=B
+    const T1 &A,     // input array A (e.g., DCArrayKokkos <double>) in LU decomp format
+    const T2 &perm,  // permutations (e.g., DCArrayKokkos <size_t>)
+    T3 &b){          // RHS and is answer x to Ax=B (e.g., DCArrayKokkos <double>)
 
-    const int n = A.dims(0);    // size of matrix
+    const int n = A.dims(0);    // size of array
 
     CArrayKokkos <double> val(1); // a helper variable that carries a scalar
 
@@ -524,14 +524,14 @@ void LU_backsub_host(
 // -----------------------
 // LU determinant function 
 //  Input:  A filled in LUPDecompose; N - dimension.
-//  Output: determinate of original A matrix
+//  Output: determinate of original A array
 // ----------------------- 
 template <typename T>
 double LU_determinant_host(
-    T &A,               // input matrix
+    T &A,               // input array (e.g., DCArrayKokkos <double>)
     const int parity){  // parity (+1 0r -1)
 
-    const int n = A.dims(0);    // size of matrix
+    const int n = A.dims(0);    // size of array
 
     double res = (double)(parity);
     double prod_tally;
@@ -554,12 +554,12 @@ double LU_determinant_host(
 // ------------------ 
 template <typename T1, typename T2, typename T3, typename T4>
 void LU_invert_host(
-    T1 &A,       // input matrix
-    T2 &perm,    // permutations (array<size_t>)
-    T3 &inv_mat, // inverse matrix
-    T4 &col) {   // tmp array
+    T1 &A,       // input array (e.g., DCArrayKokkos <double>)
+    T2 &perm,    // permutations (e.g., DCArrayKokkos <size_t> )
+    T3 &inv_mat, // inverse array (e.g., DCArrayKokkos <double>)
+    T4 &col) {   // tmp array (e.g., DCArrayKokkos <double>)
 
-    const size_t n = A.dims(0);    // size of matrix
+    const size_t n = A.dims(0);    // size of array
 
 
     for(size_t j = 0; j < n; j++){
@@ -588,19 +588,19 @@ void LU_invert_host(
 // A[n,n]
 // b[n], note answer, x, is returned in b
 template <typename T1, typename T2, typename T3, typename T4>
-int LU_solver_host(T1 &A, 
-                   T2 &b,
-                   T3 &perm,  // permutations (array <size_t>)
-                   T4 &vv,
+int LU_solver_host(T1 &A,     // e.g., DCArrayKokkos <double> 
+                   T2 &b,     // e.g., DCArrayKokkos <double>
+                   T3 &perm,  // permutations (e.g., DCArrayKokkos <size_t>)
+                   T4 &vv,    // e.g., CArrayKokkos <double>
                    int &parity) {
 
 
     int singular = 0; 
     parity = 0;
-    singular = LU_decompose_host(A, perm, vv, parity);  // A is returned as the LU matrix  
+    singular = LU_decompose_host(A, perm, vv, parity);  // A is returned as the LU array  
     
     if(singular==0){
-        printf("ERROR: matrix is singluar \n");
+        printf("ERROR: array is singluar \n");
         return 0;
     }
 

--- a/solvers/lu_solver.hpp
+++ b/solvers/lu_solver.hpp
@@ -53,11 +53,12 @@ const double TINY = 1e-15;
 
 
 // the function is run on the GPU
+template <typename T1, typename T2, typename T3>
 KOKKOS_FUNCTION
 int LU_decompose(
-    const DCArrayKokkos <double> &A, // matrix A passed in and is sent out in LU decomp format
-    const DCArrayKokkos <size_t> &perm,  // permutations
-    const CArrayKokkos <double> &vv,
+    const T1 &A,     // matrix A passed in and is sent out in LU decomp format
+    const T2 &perm,  // permutations (array <size_t>)
+    const T3 &vv,
     int &parity) {                 // parity (+1 or -1)
                           
     const int n = A.dims(0);  // size of matrix 
@@ -165,10 +166,11 @@ int LU_decompose(
 
 // this function is run on the GPU
 KOKKOS_FUNCTION
+template <typename T1, typename T2, typename T3>
 void LU_backsub(
-    const DCArrayKokkos <double> &A,     // input matrix A in LU decomp format
-    const DCArrayKokkos <size_t> &perm,  // permutations
-    const DCArrayKokkos <double> &b){          // RHS and is answer x to Ax=B
+    const T1 &A,     // input matrix A in LU decomp format
+    const T2 &perm,  // permutations (array <size_t>)
+    const T3 &b){    // RHS and is answer x to Ax=B
 
         const int n = A.dims(0);    // size of matrix
 
@@ -215,12 +217,13 @@ void LU_backsub(
 // ------------------ 
 // LU invert function 
 // ------------------ 
+template <typename T1, typename T2, typename T3, typename T4>
 KOKKOS_INLINE_FUNCTION
 void LU_invert(
-    DCArrayKokkos <double> &A,       // input matrix
-    DCArrayKokkos <size_t> &perm,    // permutations
-    DCArrayKokkos <double> &inv_mat, // inverse matrix
-    DCArrayKokkos <double> &col) {   // tmp array
+    T1 &A,       // input matrix
+    T2 &perm,    // permutations
+    T3 &inv_mat, // inverse matrix
+    T4 &col) {   // tmp array
 
     const size_t n = A.dims(0);    // size of matrix
 
@@ -249,10 +252,11 @@ void LU_invert(
 //  Input:  A filled in LUPDecompose; N - dimension.
 //  Output: determinate of original A matrix
 // ----------------------- 
+template <typename T>
 KOKKOS_INLINE_FUNCTION
 double LU_determinant(
-    DCArrayKokkos <double> &A,  // input matrix
-    const int parity){          // parity (+1 0r -1)
+    T &A,               // input matrix
+    const int parity){  // parity (+1 0r -1)
 
     const int n = A.dims(0);    // size of matrix
 
@@ -266,225 +270,6 @@ double LU_determinant(
 
 } // end function
 
-
-
-
-/////////// ViewKokkos Versions //////////
-
-
-// the function is run on the GPU
-KOKKOS_FUNCTION
-int LU_decompose(
-    const ViewCArrayKokkos <double> &A, // matrix A passed in and is sent out in LU decomp format
-    const ViewCArrayKokkos <size_t> &perm,  // permutations
-    const ViewCArrayKokkos <double> &vv,
-    int &parity) {                 // parity (+1 or -1)
-                          
-    const int n = A.dims(0);  // size of matrix 
-
-    parity = 1;
-
-    // helper variables
-    double temp;
-    
-    // search for the largest element in each row; save the scaling in the 
-    // temporary array vv and return zero if the matrix is singular 
-    for(size_t i = 0; i < n; i++) {
-        
-        double big = 0.;
-        for(size_t j = 0; j < n; j++){
-            if((temp=fabs(A(i,j))) > big){
-                big=temp;
-            }
-        }
-        
-        if(big == 0.0) return(0);
-        
-        vv(i) = big;
-    }
-
-    // the main loop for the Crout's algorithm
-    for(size_t j = 0; j < n; j++) {
-        
-        // this is the part a) of the algorithm except for i==j 
-        for(size_t i=0;i<j;i++) {
-            
-            double sum=A(i,j);
-            
-            for(size_t k=0;k<i;k++){
-                sum -= A(i,k)*A(k,j);
-            }
-
-            A(i,j) = sum;
-        }
-    
-        // initialize for the search for the largest pivot element
-        double big = 0.;
-        size_t imax = j;
-        
-        
-        // this is the part a) for i==j and part b) for i>j + pivot search 
-        for(size_t i = j; i < n; i++) {
-            
-            double sum = A(i,j);
-            
-            for(size_t k=0; k<j; k++){
-                sum -= A(i,k)*A(k,j);
-            }
-            
-            A(i,j) = sum;
-            
-            // is the figure of merit for the pivot better than the best so far?
-            if((temp = vv(i)*fabs(sum)) >= big){
-                big = temp; 
-                imax = i;
-            }
-        } // end for i
-
-        // interchange rows, if needed, change parity and the scale factor
-        if(imax != j) {
-            
-            for(size_t k = 0; k < n; k++){
-                temp = A(imax,k);
-                A(imax,k) = A(j,k);
-                A(j,k) = temp;
-            }
-            
-            parity = -(parity);
-            vv(imax) = vv(j);
-        }
-        
-        // store the index
-        perm(j) = imax;
-        // if the pivot element is zero, the matrix is singular but for some 
-        // applications a tiny number is desirable instead 
-        
-        if(A(j,j) == 0.0){
-            A(j,j) = TINY;
-        }
-        // finally, divide by the pivot element
-        
-        if(j<n-1) {
-            
-            temp=1./A(j,j);
-            for(size_t i = j+1; i < n; i++){
-                A(i,j)*=temp;
-            } // end for i
-        } // end if j
-
-    } // end for j
-    
-    return(1);
-} // end function
-
-
-
-// -------------------------------
-// LU back substitution functions 
-// -------------------------------
-
-// this function is run on the GPU
-KOKKOS_FUNCTION
-void LU_backsub(
-    const ViewCArrayKokkos <double> &A,     // input matrix A in LU decomp format
-    const ViewCArrayKokkos <size_t> &perm,  // permutations
-    const ViewCArrayKokkos <double> &b){          // RHS and is answer x to Ax=B
-
-        const int n = A.dims(0);    // size of matrix
-
-        int ii = -1;
-
-
-        // First step of backsubstitution; the only wrinkle is to unscramble 
-        // the permutation order. Note: the algorithm is optimized for a 
-        // possibility of large amount of zeroes in b
-        
-        for(size_t i = 0; i < n; i++) {
-           
-            size_t ip = perm(i);
-
-            double sum = b(ip);
-            b(ip) = b(i);
-         
-            if(ii >= 0){
-                for(size_t j = ii; j<i; j++){
-                    sum -= A(i,j)*b(j);
-                }
-            }
-            else if(sum>0){
-                ii=i;  // a nonzero element encounted
-            }
-          
-            b(i) = sum;
-        } // end loop i
-        
-        // the second step
-        for(int i=n-1; i>=0; i--) {
-            
-            double sum = b(i);
-            for(size_t j=i+1; j<n; j++){
-                sum-=A(i,j)*b(j);
-            } // end j
-       
-            b(i)=sum/A(i,i);
-        } // end loop i
-
-} // end if
-
-
-// ------------------ 
-// LU invert function 
-// ------------------ 
-KOKKOS_INLINE_FUNCTION
-void LU_invert(
-    ViewCArrayKokkos <double> &A,       // input matrix
-    ViewCArrayKokkos <size_t> &perm,    // permutations
-    ViewCArrayKokkos <double> &inv_mat, // inverse matrix
-    ViewCArrayKokkos <double> &col) {   // tmp array
-
-    const size_t n = A.dims(0);    // size of matrix
-
-
-    for(size_t j = 0; j < n; j++){
-
-        for(size_t i = 0; i < n; i++){
-            col(i) = 0.0;
-        } // end for i
-        
-        col(j) = 1.0;
-        LU_backsub(A, perm, col);
-        
-        for(size_t i = 0; i < n; i++){
-            inv_mat(i,j) = col(i);
-        } // end for i
-
-    } // end for j
-
-    return;
-
-} // end function
-
-// -----------------------
-// LU determinant function 
-//  Input:  A filled in LUPDecompose; N - dimension.
-//  Output: determinate of original A matrix
-// ----------------------- 
-KOKKOS_INLINE_FUNCTION
-double LU_determinant(
-    ViewCArrayKokkos <double> &A,  // input matrix
-    const int parity){          // parity (+1 0r -1)
-
-    const int n = A.dims(0);    // size of matrix
-
-    double res = (double)(parity);
-    
-    for(size_t j=0; j<n; j++){
-        res *= A(j,j);
-    } // end j
-
-    return(res);
-
-} // end function
 
 
 
@@ -496,10 +281,11 @@ double LU_determinant(
 
 // the function is run from the host, and kernals
 // inside this function are run on the GPU
+template <typename T1, typename T2, typename T3>
 int LU_decompose_host(
-    DCArrayKokkos <double> &A, // matrix A passed in and is sent out in LU decomp format
-    DCArrayKokkos <size_t> &perm,  // permutations
-    CArrayKokkos <double> &vv,
+    T1 &A,     // matrix A passed in and is sent out in LU decomp format
+    T2 &perm,  // permutations (array <size_t>)
+    T3 &vv,    // helper array 
     int &parity) {                 // parity (+1 or -1)
                           
     const int n = A.dims(0);  // size of matrix 
@@ -669,10 +455,11 @@ int LU_decompose_host(
 
 // the function is run from the host, and kernals
 // inside this function are run on the GPU
+template <typename T1, typename T2, typename T3>
 void LU_backsub_host(
-    const DCArrayKokkos <double> &A,     // input matrix A in LU decomp format
-    const DCArrayKokkos <size_t> &perm,  // permutations
-    DCArrayKokkos <double> &b){          // RHS and is answer x to Ax=B
+    T1 &A,     // input matrix A in LU decomp format
+    T2 &perm,  // permutations (array <size_t>)
+    T3 &b){          // RHS and is answer x to Ax=B
 
     const int n = A.dims(0);    // size of matrix
 
@@ -739,9 +526,10 @@ void LU_backsub_host(
 //  Input:  A filled in LUPDecompose; N - dimension.
 //  Output: determinate of original A matrix
 // ----------------------- 
+template <typename T>
 double LU_determinant_host(
-    DCArrayKokkos <double> &A,  // input matrix
-    const int parity){          // parity (+1 0r -1)
+    T &A,               // input matrix
+    const int parity){  // parity (+1 0r -1)
 
     const int n = A.dims(0);    // size of matrix
 
@@ -761,17 +549,15 @@ double LU_determinant_host(
 } // end function
 
 
-
-
-
 // ------------------ 
 // LU invert function 
 // ------------------ 
+template <typename T1, typename T2, typename T3, typename T4>
 void LU_invert_host(
-    DCArrayKokkos <double> &A,       // input matrix
-    DCArrayKokkos <size_t> &perm,    // permutations
-    DCArrayKokkos <double> &inv_mat, // inverse matrix
-    DCArrayKokkos <double> &col) {   // tmp array
+    T1 &A,       // input matrix
+    T2 &perm,    // permutations (array<size_t>)
+    T3 &inv_mat, // inverse matrix
+    T4 &col) {   // tmp array
 
     const size_t n = A.dims(0);    // size of matrix
 
@@ -801,10 +587,11 @@ void LU_invert_host(
 // Solve for x in Ax = b using LU
 // A[n,n]
 // b[n], note answer, x, is returned in b
-int LU_solver_host(DCArrayKokkos <double> &A, 
-                   DCArrayKokkos <double> &b,
-                   DCArrayKokkos <size_t> &perm,  // permutations
-                   CArrayKokkos <double> &vv,
+template <typename T1, typename T2, typename T3, typename T4>
+int LU_solver_host(T1 &A, 
+                   T2 &b,
+                   T3 &perm,  // permutations (array <size_t>)
+                   T4 &vv,
                    int &parity) {
 
 

--- a/solvers/qr_solver.hpp
+++ b/solvers/qr_solver.hpp
@@ -49,8 +49,9 @@ using namespace mtr;
 
 
 // Transpose matrix
-void transpose_host(const DCArrayKokkos <double> &A,
-                    DCArrayKokkos <double> &At) {
+template <typename T1, typename T2>
+void transpose_host(const T1 &A,
+                    T2 &At) {
 
     size_t m = A.dims(0);
     size_t n = A.dims(1);

--- a/solvers/qr_solver.hpp
+++ b/solvers/qr_solver.hpp
@@ -50,8 +50,8 @@ using namespace mtr;
 
 // Transpose matrix
 template <typename T1, typename T2>
-void transpose_host(const T1 &A,
-                    T2 &At) {
+void transpose_host(const T1 &A,  // e.g., DCArrayKokkos <double>
+                    T2 &At) {     // e.g., DCArrayKokkos <double>
 
     size_t m = A.dims(0);
     size_t n = A.dims(1);
@@ -67,9 +67,10 @@ void transpose_host(const T1 &A,
 
 
 // Back substitution to solve Rx = y
-void QR_backsub_host(const DCArrayKokkos <double> &R, 
-                     const DCArrayKokkos <double> &y,
-                     DCArrayKokkos <double> &x) {
+template <typename T1, typename T2, typename T3>
+void QR_backsub_host(const T1 &R, // e.g., DCArrayKokkos <double>
+                     const T2 &y, // e.g., DCArrayKokkos <double>
+                     T3 &x) {     // e.g., DCArrayKokkos <double>
     
     size_t n = R.dims(0);
     
@@ -99,9 +100,10 @@ void QR_backsub_host(const DCArrayKokkos <double> &R,
 } // end function
 
 // QR Decomposition using Modified Gram-Schmidt
-void QR_decompose_host(const DCArrayKokkos <double> &A, 
-                       DFArrayKokkos <double> &Q, 
-                       DCArrayKokkos <double> &R) {
+template <typename T1, typename T2, typename T3>
+void QR_decompose_host(const T1 &A,  // e.g., DCArrayKokkos <double> 
+                       T2 &Q,        // e.g., DFArrayKokkos <double>
+                       T3 &R) {      // e.g., DCArrayKokkos <double>
 
 
     const size_t m = A.dims(0);
@@ -196,9 +198,9 @@ void QR_decompose_host(const DCArrayKokkos <double> &A,
 
 } // end function
 
-
-double QR_determinant_host(const DFArrayKokkos <double> &Q,
-                           const DCArrayKokkos <double> &R)
+template <typename T1, typename T2>
+double QR_determinant_host(const T1 &Q, // e.g., DFArrayKokkos <double> 
+                           const T2 &R) // e.g., DCArrayKokkos <double> 
 {
     //const size_t m = Q.dims(0);
     const size_t n = Q.dims(1);
@@ -260,9 +262,10 @@ double QR_determinant_host(const DFArrayKokkos <double> &Q,
 // A[m,n]
 // x[n]
 // b[m]
-void QR_solver_host(const DCArrayKokkos <double> &A, 
-                    const DCArrayKokkos <double> &b,
-                    DCArrayKokkos <double> &x) {
+template <typename T1, typename T2, typename T3>
+void QR_solver_host(const T1 &A, // e.g., DCArrayKokkos <double> 
+                    const T2 &b, // e.g., DCArrayKokkos <double>
+                    T3 &x) {     // e.g., DCArrayKokkos <double>
     
     const size_t m = A.dims(0);
     const size_t n = A.dims(1);
@@ -299,10 +302,11 @@ void QR_solver_host(const DCArrayKokkos <double> &A,
 //   QR_decompose_host(Q, R);
 // dimensions: Q(m,n,"Q");
 // dimenions: R(n,n,"R");
-void QR_solver_host(const DFArrayKokkos <double> &Q,
-                    const DCArrayKokkos <double> &R,
-                    const DCArrayKokkos <double> &b,
-                    DCArrayKokkos <double> &x) {
+template <typename T1, typename T2, typename T3, typename T4>
+void QR_solver_host(const T1 &Q,  // e.g., DFArrayKokkos <double> 
+                    const T2 &R,  // e.g., DCArrayKokkos <double>
+                    const T3 &b,  // e.g., DCArrayKokkos <double>
+                    T4 &x) {      // e.g., DCArrayKokkos <double>
     
     const size_t m = Q.dims(0);
     const size_t n = Q.dims(1);


### PR DESCRIPTION
Expanded support for diverse MATAR device types, and reduced coding by using templates on types passed into solvers.

The coding was tested on CPUs and GPUs, all tests pass.